### PR TITLE
Obtain grid dimensionality from the reference cell

### DIFF
--- a/src/grids.jl
+++ b/src/grids.jl
@@ -3,7 +3,7 @@ abstract type AbstractGrid{C <: AbstractCell, N <: Tuple} end
 floattype(::Type{<:AbstractGrid{C}}) where {C} = floattype(C)
 arraytype(::Type{<:AbstractGrid{C}}) where {C} = arraytype(C)
 celltype(::Type{<:AbstractGrid{C}}) where {C} = C
-Base.ndims(::Type{<:AbstractGrid{C, N}}) where {C, N} = tuple_length(N)
+Base.ndims(::Type{<:AbstractGrid{C}}) where {C} = ndims(C)
 Base.size(::Type{<:AbstractGrid{C, N}}) where {C, N} = size_to_tuple(N)
 Base.length(::Type{<:AbstractGrid{C, N}}) where {C, N} = tuple_prod(N)
 

--- a/test/grids.jl
+++ b/test/grids.jl
@@ -21,14 +21,14 @@
         @test floattype(grid) == T
         @test arraytype(grid) <: A
         @test celltype(grid) == typeof(cell)
-        @test Base.ndims(grid) == Base.ndims(conn)
+        @test Base.ndims(grid) == Base.ndims(cell)
         @test size(grid) == size(conn)
         @test length(grid) == length(conn)
 
         @test floattype(typeof(grid)) == T
         @test arraytype(typeof(grid)) <: A
         @test celltype(typeof(grid)) == typeof(cell)
-        @test Base.ndims(typeof(grid)) == Base.ndims(conn)
+        @test Base.ndims(typeof(grid)) == Base.ndims(cell)
         @test size(typeof(grid)) == size(conn)
         @test length(typeof(grid)) == length(conn)
 


### PR DESCRIPTION
In the case of a cubed sphere grid the size of connectivity array (`N`)
doesn't correspond to the number of physical dimensions.