### PR TITLE
Set g₂₁, g₂₂ correctly in advection example

### DIFF
--- a/examples/advection/advection_2d.jl
+++ b/examples/advection/advection_2d.jl
@@ -39,7 +39,7 @@ function run(solution, FT, A, N, K; outputvtk=false, vtkdir="output")
 
     g, J = components(metrics(grid))
 
-    g₁₁, g₁₂, g₂₁, g₂₂ = components(g)
+    g₁₁, g₁₂, _, g₂₁, g₂₂ = components(g)
 
     M = mass(cell)
     D₁, D₂ = derivatives(cell)


### PR DESCRIPTION
In the current code it would be that
```julia
  g₂₁, g₂₂
```
were really set to
```julia
  g₁₃, g₂₁
```
respectively